### PR TITLE
Deployment: Smithery config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-forked https://github.com/modelcontextprotocol/servers/tree/main
-
 # Knowledge Graph Memory Server
+[![smithery badge](https://smithery.ai/badge/@yodakeisuke/mcp-memory-domain-knowledge)](https://smithery.ai/server/@yodakeisuke/mcp-memory-domain-knowledge)
+
 A basic implementation of persistent memory using a local knowledge graph. This lets Claude remember information about the user across chats.
 
 ## Core Concepts

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,0 +1,16 @@
+# Smithery configuration file: https://smithery.ai/docs/config#smitheryyaml
+
+startCommand:
+  type: stdio
+  configSchema:
+    # JSON Schema defining the configuration options for the MCP.
+    type: object
+    properties:
+      memoryFilePath:
+        type: string
+        description: Path to the memory storage JSON file. Defaults to 'memory.json' in
+          the server directory.
+  commandFunction:
+    # A function that produces the CLI command to start the MCP on stdio.
+    |-
+    config=>({command:'node',args:['dist/index.js'],env:config.memoryFilePath ? {MEMORY_FILE_PATH:config.memoryFilePath} : {}})


### PR DESCRIPTION
This pull request introduces the following updates:

- **Smithery Configuration**: Adds a Smithery YAML file, which specifies how to start the MCP and the configuration options it supports. It allows you to [deploy](https://smithery.ai/docs/deployments) your MCP to [Smithery](https://smithery.ai?utm_campaign=pr), serving it over WebSockets so end-users do not need to install additional dependencies. To deploy, merge this PR, then visit your [server page](https://smithery.ai/server/@yodakeisuke/mcp-memory-domain-knowledge?utm_campaign=pr&modal=claim) and click "Deploy" under the deployments page.
- **README**: Updates the README to include a popularity badge.

Please review these updates to verify their accuracy for your server and feel free to customize it to your needs. Let me know if you have any questions. 🙂